### PR TITLE
Make it fast :)

### DIFF
--- a/test/LudoBench.hs
+++ b/test/LudoBench.hs
@@ -55,10 +55,10 @@ instance NFData Next.PCGen64 where
 -}
 
 {-
- ______ ______      __  ____                  _     
-|  ____/ __ \ \    / / |  _ \                | |    
-| |__ | |  | \ \  / /  | |_) | ___ _ __   ___| |__  
-|  __|| |  | |\ \/ /   |  _ < / _ \ '_ \ / __| '_ \ 
+ ______ ______      __  ____                  _
+|  ____/ __ \ \    / / |  _ \                | |
+| |__ | |  | \ \  / /  | |_) | ___ _ __   ___| |__
+|  __|| |  | |\ \/ /   |  _ < / _ \ '_ \ / __| '_ \
 | |   | |__| | \  /    | |_) |  __/ | | | (__| | | |
 |_|    \____/   \/     |____/ \___|_| |_|\___|_| |_|
 -}
@@ -103,10 +103,10 @@ fovMain = defaultMain [
     ]
 
 {-
- _____  _   _  _____   ____                  _     
-|  __ \| \ | |/ ____| |  _ \                | |    
-| |__) |  \| | |  __  | |_) | ___ _ __   ___| |__  
-|  _  /| . ` | | |_ | |  _ < / _ \ '_ \ / __| '_ \ 
+ _____  _   _  _____   ____                  _
+|  __ \| \ | |/ ____| |  _ \                | |
+| |__) |  \| | |  __  | |_) | ___ _ __   ___| |__
+|  _  /| . ` | | |_ | |  _ < / _ \ '_ \ / __| '_ \
 | | \ \| |\  | |__| | | |_) |  __/ | | | (__| | | |
 |_|  \_\_| \_|\_____| |____/ \___|_| |_|\___|_| |_|
 -}
@@ -114,19 +114,25 @@ fovMain = defaultMain [
 loopNext :: RandomGen s => s -> s
 loopNext = (execState (replicateM 1000000 (state System.Random.next)))
 
+loop :: Int -> PCGen32 -> PCGen32
+loop 0 x = x
+loop n x = let (NextGen i gen) = next' x in
+           seq i $ loop (n-1) gen
+
 pcgenMain = defaultMain [
     bench "StdGen, 1 million uses" $ nf loopNext (mkStdGen 12345),
-    bench "Curr PCGen32, 1 million uses" $ nf loopNext (Curr.mkPCGen32 5 5),
+    bench "Curr PCGen32, 1 million uses" $ nf (loop 1000000) (Curr.mkPCGen32 5 5),
+        bench "Curr PCGen32, 1 million uses" $ nf loopNext (Curr.mkPCGen32 5 5),
     bench "Curr PCGen64, 1 million uses" $ nf loopNext (Curr.mkPCGen64 5 5 7 7)
     --bench "Next PCGen32, 10 million uses" $ nf loopNext (Next.mkPCGen32 5 5),
     --bench "Next PCGen64, 10 million uses" $ nf loopNext (Next.mkPCGen64 5 5 7 7)
     ]
 
 {-
-               _          ____                  _     
-    /\        | |        |  _ \                | |    
-   /  \  _   _| |_ ___   | |_) | ___ _ __   ___| |__  
-  / /\ \| | | | __/ _ \  |  _ < / _ \ '_ \ / __| '_ \ 
+               _          ____                  _
+    /\        | |        |  _ \                | |
+   /  \  _   _| |_ ___   | |_) | ___ _ __   ___| |__
+  / /\ \| | | | __/ _ \  |  _ < / _ \ '_ \ / __| '_ \
  / ____ \ |_| | || (_) | | |_) |  __/ | | | (__| | | |
 /_/    \_\__,_|\__\___/  |____/ \___|_| |_|\___|_| |_|
 -}


### PR DESCRIPTION
Here are the benchmarks results
```
benchmarking StdGen, 1 million uses
time                 476.5 ms   (435.8 ms .. 556.8 ms)
                     0.997 R²   (0.993 R² .. 1.000 R²)
mean                 448.8 ms   (438.5 ms .. 458.7 ms)
std dev              16.70 ms   (0.0 s .. 17.08 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking Curr PCGen32, 1 million uses
time                 1.294 ms   (1.287 ms .. 1.301 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 1.292 ms   (1.285 ms .. 1.299 ms)
std dev              23.73 μs   (20.21 μs .. 28.05 μs)

benchmarking Curr PCGen32, 1 million uses
time                 340.4 ms   (333.1 ms .. 357.3 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 342.1 ms   (339.5 ms .. 343.6 ms)
std dev              2.293 ms   (0.0 s .. 2.564 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking Curr PCGen64, 1 million uses
time                 335.6 ms   (319.3 ms .. 358.6 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 342.0 ms   (338.9 ms .. 343.6 ms)
std dev              2.658 ms   (0.0 s .. 2.837 ms)
variance introduced by outliers: 19% (moderately inflated)
```
So it seems to be about 300 times faster :) It also seems to return the same results at least from a quick look, but I might have screwed up somewhere.

Without looking two deep into it (I don’t have time right now) the reasons why this is faster are mostly
- Tuples are lazy and thereby shitty for state in a loop which really should be strict
- The state in the state monad is lazy so it’s probably only evaluated at the very end

Sorry for the messy diff, my editor deletes trailing whitespace on save and I’m too lazy to disable it.